### PR TITLE
Remove manifest target settings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -36,9 +36,6 @@ let package = Package(
             dependencies: [
                 "BlackBox",
                 .product(name: "FirebaseCrashlytics", package: "firebase-ios-sdk")
-            ],
-            swiftSettings: [
-                .treatAllWarnings(as: .error)
             ]
         ),
         .testTarget(
@@ -46,9 +43,6 @@ let package = Package(
             dependencies: [
                 .targetItem(name: targetName, condition: nil),
                 "BlackBox"
-            ],
-            swiftSettings: [
-                .treatAllWarnings(as: .error)
             ]
         ),
     ],


### PR DESCRIPTION
## Summary
- remove manifest-level `swiftSettings` from the library target
- remove manifest-level `swiftSettings` from the test target
- stop forcing warnings-as-errors from the package manifest

## Testing
- `xcodebuild test -scheme BlackBoxFirebaseCrashlytics -destination 'platform=OS X' SWIFT_SUPPRESS_WARNINGS=NO -quiet`\n